### PR TITLE
Add fallback when media_url not set

### DIFF
--- a/src/InstagramApi.php
+++ b/src/InstagramApi.php
@@ -113,7 +113,7 @@ class InstagramApi
                 'id' => $media->id,
                 'caption' => isset($media->caption) ? $media->caption : null,
                 'media_type' => $media->media_type, // Can be IMAGE, VIDEO, or CAROUSEL_ALBUM.
-                'media_url' =>  $media->media_url,
+                'media_url' =>  $media->media_url ?? '',
                 'permalink' => $media->permalink,
                 'thumbnail_url' => isset($media->thumbnail_url) ? $media->thumbnail_url : null,
                 'timestamp' => $media->timestamp,


### PR DESCRIPTION
Sometimes the media_url is not set, for instance when a post is flagged for copyright violations.
The current behavior of the plugin is to fail with` Undefined property: stdClass::$media_url` as error message and not show any images at all.

This change adds a fallback empty url so that at least other posts are shown. However a permanent fix would probable involve ignoring that post entirely.


